### PR TITLE
Simplify vehicle form

### DIFF
--- a/src/pages/VehicleQuoteForm.tsx
+++ b/src/pages/VehicleQuoteForm.tsx
@@ -25,9 +25,7 @@ const VehicleQuoteForm = () => {
     licensePlate: '',
     vehicleType: '',
     brand: '',
-    model: '',
     year: '',
-    trim: '',
     transmission: '',
     hasLien: 'no',
     invoiceValue: '',
@@ -122,9 +120,7 @@ const VehicleQuoteForm = () => {
       // Validar datos del vehículo
       if (!formState.vehicleType) newErrors.vehicleType = 'Este campo es obligatorio';
       if (!formState.brand) newErrors.brand = 'Este campo es obligatorio';
-      if (!formState.model) newErrors.model = 'Este campo es obligatorio';
       if (!formState.year) newErrors.year = 'Este campo es obligatorio';
-      if (!formState.trim) newErrors.trim = 'Este campo es obligatorio';
       if (!formState.transmission) newErrors.transmission = 'Este campo es obligatorio';
     } else if (currentStep === 3) {
       // Validar información adicional
@@ -167,9 +163,7 @@ const VehicleQuoteForm = () => {
     
     if (!formState.vehicleType) allErrors.vehicleType = 'Este campo es obligatorio';
     if (!formState.brand) allErrors.brand = 'Este campo es obligatorio';
-    if (!formState.model) allErrors.model = 'Este campo es obligatorio';
     if (!formState.year) allErrors.year = 'Este campo es obligatorio';
-    if (!formState.trim) allErrors.trim = 'Este campo es obligatorio';
     if (!formState.transmission) allErrors.transmission = 'Este campo es obligatorio';
     
     if (formState.additionalEmail && !/\S+@\S+\.\S+/.test(formState.additionalEmail)) {
@@ -198,7 +192,7 @@ const VehicleQuoteForm = () => {
           if (step === 1) {
             return ['ownerName', 'identification', 'birthDate', 'address', 'phone', 'email'].includes(key);
           } else if (step === 2) {
-            return ['vehicleType', 'brand', 'model', 'year', 'trim', 'transmission'].includes(key);
+            return ['vehicleType', 'brand', 'year', 'transmission'].includes(key);
           } else if (step === 3) {
             return ['additionalEmail'].includes(key);
           }

--- a/src/pages/steps/DocumentationStep.tsx
+++ b/src/pages/steps/DocumentationStep.tsx
@@ -160,7 +160,7 @@ const DocumentationStep = ({
             files={files}
           />
           <p className="mt-2 text-sm text-gray-500">
-            Puedes adjuntar foto de la matrícula y/o copia del seguro actual (opcional)
+            Documentos requeridos: Foto de la matrícula y Foto de la cédula del tomador
           </p>
         </div>
         

--- a/src/pages/steps/VehicleInfoStep.tsx
+++ b/src/pages/steps/VehicleInfoStep.tsx
@@ -4,11 +4,9 @@ import { FormSection, SectionIcon, FormInput, FormSelect } from '../../component
 import { 
   vehicleTypes, 
   vehicleBrands, 
-  vehicleModels, 
-  years, 
-  vehicleTrim, 
-  transmission, 
-  yesNoOptions 
+  years,
+  transmission,
+  yesNoOptions
 } from '../../data/FormData';
 
 const VehicleInfoStep = ({ 
@@ -59,28 +57,16 @@ const VehicleInfoStep = ({
       </div>
       
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <FormSelect
-          label="Marca"
+        <FormInput
+          label="Marca del vehículo"
           name="brand"
-          options={vehicleBrands}
+          type="text"
           value={formState.brand}
           onChange={handleInputChange}
           required
           error={errors.brand}
         />
-        
-        <FormSelect
-          label="Modelo"
-          name="model"
-          options={vehicleModels}
-          value={formState.model}
-          onChange={handleInputChange}
-          required
-          error={errors.model}
-        />
-      </div>
-      
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
         <FormSelect
           label="Año"
           name="year"
@@ -89,16 +75,6 @@ const VehicleInfoStep = ({
           onChange={handleInputChange}
           required
           error={errors.year}
-        />
-        
-        <FormSelect
-          label="Corte"
-          name="trim"
-          options={vehicleTrim}
-          value={formState.trim}
-          onChange={handleInputChange}
-          required
-          error={errors.trim}
         />
       </div>
       


### PR DESCRIPTION
## Summary
- streamline vehicle info step: brand as text input, remove model & trim fields
- update form state and validations accordingly
- clarify required docs in documentation step

## Testing
- `npm run lint` *(fails: Unexpected any in emailService.ts, forbidden require in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6876cbf775f08321b656af040b542319