### PR TITLE
Add pet information section to pet quote form

### DIFF
--- a/src/pages/PetQuoteForm.tsx
+++ b/src/pages/PetQuoteForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { CheckCircle, AlertTriangle, ArrowRight, Heart, Users, User } from 'lucide-react';
+import { CheckCircle, AlertTriangle, ArrowRight, Heart, User } from 'lucide-react';
 import { toast } from 'sonner';
 
 // Importar componentes del sistema existente
@@ -11,7 +11,6 @@ import FormSection from '../components/FormSection';
 import { 
   FormInput,
   FormSelect,
-  FormRadioGroup,
   PhoneInput
 } from '../components/FormComponent';
 
@@ -22,90 +21,38 @@ const petData = {
     { value: 'cedula_extranjeria', label: 'Cédula de Extranjería' },
     { value: 'pasaporte', label: 'Pasaporte' },
     { value: 'nit', label: 'NIT (empresas)' }
-  ],
-  yesNoOptions: [
-    { value: 'si', label: 'Sí' },
-    { value: 'no', label: 'No' }
-  ],
-  cantidadPersonas: [
-    { value: '1', label: '1 persona' },
-    { value: '2', label: '2 personas' },
-    { value: '3', label: '3 personas' },
-    { value: '4', label: '4 personas' },
-    { value: '5', label: '5 personas' }
   ]
 };
 
 const PetQuoteForm = () => {
   const navigate = useNavigate();
   const [formState, setFormState] = useState({
-    // Información de la póliza de mascotas - tomador
+    // Información del tomador
     nombreCompleto: '',
+    email: '',
     tipoDocumento: '',
     numeroDocumento: '',
-    edad: '',
+    direccion: '',
     celular: '',
-    sufreEnfermedad: 'no',
-    cualEnfermedad: '',
-    deseaAsegurarAlguienMas: 'no',
-    cantidadPersonasAdicionales: '1',
-    
-    // Email adicional
-    email: '',
-    
-    // Personas adicionales
-    personasAdicionales: []
+
+    // Información de la mascota
+    nombreMascota: '',
+    ciudadResidencia: '',
+    edadMascota: '',
+    raza: '',
+    enfermedadesSufridas: '',
+    cirugias: ''
   });
   
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Crear formularios adicionales cuando cambia la cantidad o cuando se selecciona "Sí"
-  React.useEffect(() => {
-    if (formState.deseaAsegurarAlguienMas === 'si') {
-      const cantidad = parseInt(formState.cantidadPersonasAdicionales);
-      const personasActuales = formState.personasAdicionales.length;
-      
-      if (cantidad > personasActuales) {
-        // Agregar personas
-        const nuevasPersonas = [];
-        for (let i = personasActuales; i < cantidad; i++) {
-          nuevasPersonas.push({
-            id: Date.now() + i,
-            nombreCompleto: '',
-            tipoDocumento: '',
-            numeroDocumento: '',
-            edad: '',
-            celular: '',
-            sufreEnfermedad: 'no',
-            cualEnfermedad: ''
-          });
-        }
-        setFormState(prev => ({
-          ...prev,
-          personasAdicionales: [...prev.personasAdicionales, ...nuevasPersonas]
-        }));
-      } else if (cantidad < personasActuales) {
-        // Remover personas
-        setFormState(prev => ({
-          ...prev,
-          personasAdicionales: prev.personasAdicionales.slice(0, cantidad)
-        }));
-      }
-    } else {
-      // Si no desea asegurar a nadie más, limpiar personas adicionales
-      setFormState(prev => ({
-        ...prev,
-        personasAdicionales: []
-      }));
-    }
-  }, [formState.deseaAsegurarAlguienMas, formState.cantidadPersonasAdicionales]);
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
     
-    // Validar que la edad solo contenga números
-    if (name === 'edad') {
+    // Validar que la edad de la mascota solo contenga números
+    if (name === 'edadMascota') {
       const numValue = value.replace(/\D/g, '');
       setFormState(prev => ({
         ...prev,
@@ -128,65 +75,6 @@ const PetQuoteForm = () => {
     }
   };
 
-  const handleAdditionalPersonChange = (personaId, field, value) => {
-    setFormState(prev => ({
-      ...prev,
-      personasAdicionales: prev.personasAdicionales.map(persona => 
-        persona.id === personaId 
-          ? { ...persona, [field]: field === 'edad' ? value.replace(/\D/g, '') : value }
-          : persona
-      )
-    }));
-    
-    // Clear error when field is edited
-    const errorKey = `adicional_${personaId}_${field}`;
-    if (errors[errorKey]) {
-      setErrors(prev => {
-        const newErrors = { ...prev };
-        delete newErrors[errorKey];
-        return newErrors;
-      });
-    }
-  };
-
-  const handleAdditionalPersonPhoneChange = (personaId, value) => {
-    setFormState(prev => ({
-      ...prev,
-      personasAdicionales: prev.personasAdicionales.map(persona => 
-        persona.id === personaId 
-          ? { ...persona, celular: value }
-          : persona
-      )
-    }));
-  };
-
-  const handleRadioChange = (e) => {
-    const { name, value } = e.target;
-    setFormState(prev => ({
-      ...prev,
-      [name]: value
-    }));
-    
-    // Clear error when field is edited
-    if (errors[name]) {
-      setErrors(prev => {
-        const newErrors = { ...prev };
-        delete newErrors[name];
-        return newErrors;
-      });
-    }
-  };
-
-  const handleAdditionalPersonRadioChange = (personaId, value) => {
-    setFormState(prev => ({
-      ...prev,
-      personasAdicionales: prev.personasAdicionales.map(persona => 
-        persona.id === personaId 
-          ? { ...persona, sufreEnfermedad: value }
-          : persona
-      )
-    }));
-  };
 
   const handlePhoneChange = (value) => {
     setFormState(prev => ({
@@ -206,28 +94,19 @@ const PetQuoteForm = () => {
 
   const validateForm = () => {
     const newErrors = {};
-    
-    // Validar información de la póliza de mascotas - tomador
+
+    // Validar información del tomador
     if (!formState.nombreCompleto) newErrors.nombreCompleto = 'El campo Nombre completo es requerido';
     if (!formState.tipoDocumento) newErrors.tipoDocumento = 'El campo Tipo de documento es requerido';
     if (!formState.numeroDocumento) newErrors.numeroDocumento = 'El campo Número documento es requerido';
-    if (!formState.edad) newErrors.edad = 'El campo Edad en años es requerido';
     if (!formState.celular) newErrors.celular = 'El campo Celular es requerido';
-    if (formState.sufreEnfermedad === 'si' && !formState.cualEnfermedad) {
-      newErrors.cualEnfermedad = 'El campo ¿Cuál? es requerido';
-    }
-    
-    // Validar personas adicionales
-    formState.personasAdicionales.forEach((persona, index) => {
-      if (!persona.nombreCompleto) newErrors[`adicional_${persona.id}_nombreCompleto`] = 'El campo Nombre completo es requerido';
-      if (!persona.tipoDocumento) newErrors[`adicional_${persona.id}_tipoDocumento`] = 'El campo Tipo de documento es requerido';
-      if (!persona.numeroDocumento) newErrors[`adicional_${persona.id}_numeroDocumento`] = 'El campo Número documento es requerido';
-      if (!persona.edad) newErrors[`adicional_${persona.id}_edad`] = 'El campo Edad en años es requerido';
-      if (!persona.celular) newErrors[`adicional_${persona.id}_celular`] = 'El campo Celular es requerido';
-      if (persona.sufreEnfermedad === 'si' && !persona.cualEnfermedad) {
-        newErrors[`adicional_${persona.id}_cualEnfermedad`] = 'El campo ¿Cuál? es requerido';
-      }
-    });
+    if (!formState.direccion) newErrors.direccion = 'El campo Dirección es requerido';
+
+    // Validar información de la mascota
+    if (!formState.nombreMascota) newErrors.nombreMascota = 'El campo Nombre de la mascota es requerido';
+    if (!formState.ciudadResidencia) newErrors.ciudadResidencia = 'El campo Ciudad de residencia es requerido';
+    if (!formState.edadMascota) newErrors.edadMascota = 'El campo Edad (en años) es requerido';
+    if (!formState.raza) newErrors.raza = 'El campo Raza es requerido';
     
     // Validar email si está presente
     if (formState.email && !/\S+@\S+\.\S+/.test(formState.email)) {
@@ -322,21 +201,21 @@ const PetQuoteForm = () => {
      
      <div className="bg-white rounded-lg shadow-md border border-gray-200 overflow-hidden mb-8">
        <div className="p-6 md:p-8">
-         {/* Póliza de mascotas - tomador */}
-         <FormSection 
-           title="COTIZAR PÓLIZA DE MASCOTAS - TOMADOR" 
-           icon={<User size={24} className="text-orange-600" />}
-         >
-           <div className="space-y-6">
-             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-               <FormInput
-                 label="Nombre completo"
-                 name="nombreCompleto"
-                 value={formState.nombreCompleto}
-                 onChange={handleInputChange}
-                 required
-                 error={errors.nombreCompleto}
-               />
+        {/* Información del tomador */}
+        <FormSection
+          title="Información del Tomador"
+          icon={<User size={24} className="text-orange-600" />}
+        >
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <FormInput
+                label="Nombre completo del tomador"
+                name="nombreCompleto"
+                value={formState.nombreCompleto}
+                onChange={handleInputChange}
+                required
+                error={errors.nombreCompleto}
+              />
 
                <FormInput
                  label="Su correo electrónico"
@@ -358,164 +237,109 @@ const PetQuoteForm = () => {
                />
              </div>
 
-             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-               <FormInput
-                 label="Número documento"
-                 name="numeroDocumento"
-                 value={formState.numeroDocumento}
-                 onChange={handleInputChange}
-                 required
-                 error={errors.numeroDocumento}
-               />
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <FormInput
+                label="Número documento"
+                name="numeroDocumento"
+                value={formState.numeroDocumento}
+                onChange={handleInputChange}
+                required
+                error={errors.numeroDocumento}
+              />
 
-               <FormInput
-                 label="Edad en años"
-                 name="edad"
-                 type="number"
-                 value={formState.edad}
-                 onChange={handleInputChange}
-                 required
-                 error={errors.edad}
-               />
+              <PhoneInput
+                label="Celular"
+                name="celular"
+                value={formState.celular}
+                onChange={handlePhoneChange}
+                required
+                error={errors.celular}
+              />
 
-               <PhoneInput
-                 label="Celular"
-                 name="celular"
-                 value={formState.celular}
-                 onChange={handlePhoneChange}
-                 required
-                 error={errors.celular}
-               />
-             </div>
+              <FormInput
+                label="Dirección"
+                name="direccion"
+                value={formState.direccion}
+                onChange={handleInputChange}
+                required
+                error={errors.direccion}
+              />
+            </div>
              
-             <div className="flex gap-6">
-               <div className="flex-1">
-                 <FormRadioGroup
-                   name="sufreEnfermedad"
-                   label="¿Sufre de alguna enfermedad?"
-                   options={petData.yesNoOptions}
-                   value={formState.sufreEnfermedad}
-                   onChange={handleRadioChange}
-                   error={errors.sufreEnfermedad}
-                 />
-               </div>
-               
-               {formState.sufreEnfermedad === 'si' && (
-                 <div className="flex-1">
-                   <FormInput
-                     label="¿Cuál?"
-                     name="cualEnfermedad"
-                     value={formState.cualEnfermedad}
-                     onChange={handleInputChange}
-                     error={errors.cualEnfermedad}
-                   />
-                 </div>
-               )}
-             </div>
-             
-             <FormRadioGroup
-               name="deseaAsegurarAlguienMas"
-               label="¿Desea asegurar a alguien más en la póliza de Mascotas?"
-               options={petData.yesNoOptions}
-               value={formState.deseaAsegurarAlguienMas}
-               onChange={handleRadioChange}
-               error={errors.deseaAsegurarAlguienMas}
-             />
-             
-             {formState.deseaAsegurarAlguienMas === 'si' && (
-               <FormSelect
-                 label="¿Cuántas personas adicionales?"
-                 name="cantidadPersonasAdicionales"
-                 options={petData.cantidadPersonas}
-                 value={formState.cantidadPersonasAdicionales}
-                 onChange={handleInputChange}
-               />
-             )}
            </div>
-         </FormSection>
+          </FormSection>
 
-         {/* Personas adicionales */}
-         {formState.deseaAsegurarAlguienMas === 'si' && formState.personasAdicionales.map((persona, index) => (
-           <FormSection 
-             key={persona.id}
-             title={`PERSONA ADICIONAL ${index + 1}`}
-             icon={<Users size={24} className="text-orange-400" />}
-           >
-             <div className="space-y-6">
-               <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                 <FormInput
-                   label="Nombre completo"
-                   value={persona.nombreCompleto}
-                   onChange={(e) => handleAdditionalPersonChange(persona.id, 'nombreCompleto', e.target.value)}
-                   required
-                   error={errors[`adicional_${persona.id}_nombreCompleto`]}
-                 />
-                 
-                 <FormSelect
-                   label="Tipo de documento"
-                   options={petData.tipoDocumento}
-                   value={persona.tipoDocumento}
-                   onChange={(e) => handleAdditionalPersonChange(persona.id, 'tipoDocumento', e.target.value)}
-                   required
-                   error={errors[`adicional_${persona.id}_tipoDocumento`]}
-                 />
-                 
-                 <FormInput
-                   label="Número documento"
-                   value={persona.numeroDocumento}
-                   onChange={(e) => handleAdditionalPersonChange(persona.id, 'numeroDocumento', e.target.value)}
-                   required
-                   error={errors[`adicional_${persona.id}_numeroDocumento`]}
-                 />
-               </div>
-               
-               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                 <FormInput
-                   label="Edad en años"
-                   type="number"
-                   value={persona.edad}
-                   onChange={(e) => handleAdditionalPersonChange(persona.id, 'edad', e.target.value)}
-                   required
-                   error={errors[`adicional_${persona.id}_edad`]}
-                 />
-                 
-                 <PhoneInput
-                   label="Celular"
-                   value={persona.celular}
-                   onChange={(value) => handleAdditionalPersonPhoneChange(persona.id, value)}
-                   required
-                   error={errors[`adicional_${persona.id}_celular`]}
-                 />
-               </div>
-               
-               <div className="flex gap-6">
-                 <div className="flex-1">
-                   <FormRadioGroup
-                     name={`sufreEnfermedad_${persona.id}`}
-                     label="¿Sufre de alguna enfermedad?"
-                     options={petData.yesNoOptions}
-                     value={persona.sufreEnfermedad}
-                     onChange={(e) => handleAdditionalPersonRadioChange(persona.id, e.target.value)}
-                     error={errors[`adicional_${persona.id}_sufreEnfermedad`]}
-                   />
-                 </div>
-                 
-                 {persona.sufreEnfermedad === 'si' && (
-                   <div className="flex-1">
-                     <FormInput
-                       label="¿Cuál?"
-                       value={persona.cualEnfermedad}
-                       onChange={(e) => handleAdditionalPersonChange(persona.id, 'cualEnfermedad', e.target.value)}
-                       error={errors[`adicional_${persona.id}_cualEnfermedad`]}
-                     />
-                   </div>
-                 )}
-               </div>
-             </div>
-           </FormSection>
-         ))}
+          {/* Información de la Mascota */}
+          <FormSection title="Información de la Mascota">
+            <div className="space-y-6">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <FormInput
+                  label="Nombre de la mascota"
+                  name="nombreMascota"
+                  value={formState.nombreMascota}
+                  onChange={handleInputChange}
+                  required
+                  error={errors.nombreMascota}
+                />
 
-         {/* Información adicional */}
+                <FormInput
+                  label="Ciudad de residencia"
+                  name="ciudadResidencia"
+                  value={formState.ciudadResidencia}
+                  onChange={handleInputChange}
+                  required
+                  error={errors.ciudadResidencia}
+                />
+
+                <FormInput
+                  label="Edad (en años)"
+                  name="edadMascota"
+                  type="number"
+                  value={formState.edadMascota}
+                  onChange={handleInputChange}
+                  required
+                  error={errors.edadMascota}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <FormInput
+                  label="Raza"
+                  name="raza"
+                  value={formState.raza}
+                  onChange={handleInputChange}
+                  required
+                  error={errors.raza}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Enfermedades sufridas</label>
+                  <textarea
+                    name="enfermedadesSufridas"
+                    value={formState.enfermedadesSufridas}
+                    onChange={handleInputChange}
+                    rows={3}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#0A4958] focus:border-[#0A4958]"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Cirugías que se le han hecho</label>
+                  <textarea
+                    name="cirugias"
+                    value={formState.cirugias}
+                    onChange={handleInputChange}
+                    rows={3}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#0A4958] focus:border-[#0A4958]"
+                  />
+                </div>
+              </div>
+            </div>
+          </FormSection>
+
+          {/* Información adicional */}
          <FormSection
            title="INFORMACIÓN ADICIONAL"
          >


### PR DESCRIPTION
## Summary
- reorganize PetQuoteForm sections
- split owner info from pet info
- add pet fields and validation

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-explicit-any`, `@typescript-eslint/no-require-imports`)*

------
https://chatgpt.com/codex/tasks/task_e_6876cfb1ca4483218faf3b97f8f9acbc